### PR TITLE
[Server] User Authentication

### DIFF
--- a/cago-server/.coveragerc
+++ b/cago-server/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+omit = 
+    manage.py
+    cago/asgi.py
+    cago/wsgi.py
+    cago/settings/*
+    **/migrations/*
+
+[report]
+ignore_errors = True
+skip_empty = True
+
+[html]
+title = Cago API coverage report

--- a/cago-server/.isort.cfg
+++ b/cago-server/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/cago-server/cago/ping/urls.py
+++ b/cago-server/cago/ping/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 
+app_name = "ping"
+
 urlpatterns = [
-    path("", views.PingAPIView.as_view(), name="ping"),
+    path("", views.PingAPIView.as_view(), name="index"),
 ]

--- a/cago-server/cago/settings/base.py
+++ b/cago-server/cago/settings/base.py
@@ -39,7 +39,10 @@ MIDDLEWARE = [
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTStatelessUserAuthentication",
-    )
+    ),
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
+    ],
 }
 
 

--- a/cago-server/cago/settings/base.py
+++ b/cago-server/cago/settings/base.py
@@ -84,7 +84,7 @@ WSGI_APPLICATION = "cago.wsgi.application"
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/
 
-LANGUAGE_CODE = "ko-KR"
+LANGUAGE_CODE = "en-US"
 
 TIME_ZONE = "Asia/Seoul"
 

--- a/cago-server/cago/settings/base.py
+++ b/cago-server/cago/settings/base.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "rest_framework",
     "rest_framework_simplejwt",
+    "corsheaders",
     "drf_spectacular",
     "cago.cafe",
     "cago.ping",
@@ -29,6 +30,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -82,6 +84,12 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
+]
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+    "https://cago.fun",
 ]
 
 WSGI_APPLICATION = "cago.wsgi.application"

--- a/cago-server/cago/settings/base.py
+++ b/cago-server/cago/settings/base.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     "rest_framework_simplejwt",
     "corsheaders",
     "drf_spectacular",
+    "drf_standardized_errors",
     "cago.cafe",
     "cago.ping",
     "cago.user",
@@ -47,6 +48,7 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
 }
 
 

--- a/cago-server/cago/settings/base.py
+++ b/cago-server/cago/settings/base.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django_extensions",
     "rest_framework",
+    "rest_framework_simplejwt",
     "cago.cafe",
     "cago.ping",
     "cago.user",
@@ -34,6 +35,13 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTStatelessUserAuthentication",
+    )
+}
+
 
 TEMPLATES = [
     {

--- a/cago-server/cago/settings/base.py
+++ b/cago-server/cago/settings/base.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "rest_framework",
     "rest_framework_simplejwt",
+    "drf_spectacular",
     "cago.cafe",
     "cago.ping",
     "cago.user",
@@ -43,6 +44,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 
@@ -105,3 +107,16 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Cago API",
+    "DESCRIPTION": "World's best website.",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "COMPONENT_SPLIT_REQUEST": True,
+    "COMPONENT_NO_READ_ONLY_REQUIRED": True,
+    "SERVERS": [
+        {"url": "https://api.cago.fun", "description": "Official Cago API server"},
+        {"url": "/", "description": "Local server"},
+    ],
+}

--- a/cago-server/cago/settings/development.py
+++ b/cago-server/cago/settings/development.py
@@ -14,3 +14,5 @@ DATABASES = {
         "NAME": BASE_DIR / "db.sqlite3",
     }
 }
+
+SECURE_COOKIE = False

--- a/cago-server/cago/settings/production.py
+++ b/cago-server/cago/settings/production.py
@@ -21,3 +21,5 @@ DATABASES = {
         "PORT": "5432",
     }
 }
+
+SECURE_COOKIE = True

--- a/cago-server/cago/urls.py
+++ b/cago-server/cago/urls.py
@@ -15,9 +15,25 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("auth/", include("cago.user.urls", namespace="auth")),
     path("ping/", include("cago.ping.urls", namespace="ping")),
+    path("schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "schema/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
 ]

--- a/cago-server/cago/urls.py
+++ b/cago-server/cago/urls.py
@@ -18,5 +18,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("auth/", include("cago.user.urls", namespace="auth")),
     path("ping/", include("cago.ping.urls")),
 ]

--- a/cago-server/cago/urls.py
+++ b/cago-server/cago/urls.py
@@ -19,5 +19,5 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("auth/", include("cago.user.urls", namespace="auth")),
-    path("ping/", include("cago.ping.urls")),
+    path("ping/", include("cago.ping.urls", namespace="ping")),
 ]

--- a/cago-server/cago/user/models.py
+++ b/cago-server/cago/user/models.py
@@ -1,6 +1,9 @@
 from django.contrib.auth.hashers import make_password
-from django.contrib.auth.models import (AbstractBaseUser, BaseUserManager,
-                                        PermissionsMixin)
+from django.contrib.auth.models import (
+    AbstractBaseUser,
+    BaseUserManager,
+    PermissionsMixin,
+)
 from django.db import models
 from django.utils import timezone
 

--- a/cago-server/cago/user/serializers.py
+++ b/cago-server/cago/user/serializers.py
@@ -15,7 +15,7 @@ class SignUpSerializer(serializers.ModelSerializer):
     def validate_password_confirm(self, password_confirm):
         password = self.get_initial().get("password")
         if password != password_confirm:
-            raise serializers.ValidationError("Password does not match")
+            raise serializers.ValidationError("password does not match.")
 
         return password_confirm
 

--- a/cago-server/cago/user/serializers.py
+++ b/cago-server/cago/user/serializers.py
@@ -1,0 +1,26 @@
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class SignUpSerializer(serializers.ModelSerializer):
+    password_confirm = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ["id", "email", "password", "password_confirm"]
+        extra_kwargs = {"password": {"write_only": True}}
+
+    def validate_password_confirm(self, password_confirm):
+        password = self.get_initial().get("password")
+        if password != password_confirm:
+            raise serializers.ValidationError("Password does not match")
+
+        return password_confirm
+
+    def create(self, validated_data):
+        validated_data.pop("password_confirm", None)
+        user = User.objects.create_user(**validated_data)
+
+        return user

--- a/cago-server/cago/user/tests.py
+++ b/cago-server/cago/user/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/cago-server/cago/user/tests/test_api_auth.py
+++ b/cago-server/cago/user/tests/test_api_auth.py
@@ -1,0 +1,140 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import AccessToken, RefreshToken
+
+User = get_user_model()
+
+
+class LoginAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_email = "test1@test.com"
+        cls.user_password = "qwer1234"
+        cls.user = User.objects.create_user(
+            email=cls.user_email, password=cls.user_password
+        )
+
+    def test_login_success(self):
+        response = self.client.post(
+            reverse("auth:login"),
+            {"email": self.user_email, "password": self.user_password},
+        )
+        self.assertContains(response, "access")
+
+        data = response.json()
+        access_token = AccessToken(data.get("access"))
+        refresh_token = RefreshToken(data.get("refresh"))
+        self.assertEqual(access_token.get("user_id"), self.user.id)
+        self.assertEqual(refresh_token.get("user_id"), self.user.id)
+
+    def test_after_login(self):
+        access_token = AccessToken.for_user(self.user)
+        response = self.client.get(
+            reverse("ping:index"), HTTP_AUTHORIZATION="Bearer " + str(access_token)
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_login_invalid_credentials(self):
+        response = self.client.post(
+            reverse("auth:login"),
+            {"email": self.user_email, "password": self.user_password + "0"},
+        )
+        self.assertContains(
+            response, "no_active_account", status_code=status.HTTP_401_UNAUTHORIZED
+        )
+
+
+class SignUpAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_email = "test1@test.com"
+        cls.user_password = "qwer1234"
+
+    def test_signup_success(self):
+        response = self.client.post(
+            reverse("auth:signup"),
+            {
+                "email": self.user_email,
+                "password": self.user_password,
+                "password_confirm": self.user_password,
+            },
+        )
+        self.assertContains(
+            response, self.user_email, status_code=status.HTTP_201_CREATED
+        )
+
+    def test_signup_invalid_password_confirm(self):
+        response = self.client.post(
+            reverse("auth:signup"),
+            {
+                "email": self.user_email,
+                "password": self.user_password,
+                "password_confirm": self.user_password + "0",
+            },
+        )
+        self.assertContains(
+            response, "password_confirm", status_code=status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_signup_duplciate_email(self):
+        User.objects.create_user(email=self.user_email, password=self.user_password)
+        response = self.client.post(
+            reverse("auth:signup"),
+            {
+                "email": self.user_email,
+                "password": self.user_password,
+                "password_confirm": self.user_password,
+            },
+        )
+        self.assertContains(response, "email", status_code=status.HTTP_400_BAD_REQUEST)
+
+
+class RefrehAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email="test1@test.com", password="qwer1234")
+        cls.refresh_token = RefreshToken.for_user(cls.user)
+
+    def test_refresh_success(self):
+        response = self.client.post(
+            reverse("auth:refresh"), {"refresh": str(self.refresh_token)}
+        )
+        self.assertContains(response, "access")
+
+    def test_refresh_invalid_token(self):
+        response = self.client.post(
+            reverse("auth:refresh"), {"refresh": str(self.refresh_token) + "0"}
+        )
+        self.assertContains(
+            response, "token_not_valid", status_code=status.HTTP_401_UNAUTHORIZED
+        )
+
+
+class VerifyAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email="test1@test.com", password="qwer1234")
+        cls.access_token = AccessToken.for_user(cls.user)
+        cls.refresh_token = RefreshToken.for_user(cls.user)
+
+    def test_verify_access_success(self):
+        response = self.client.post(
+            reverse("auth:verify"), {"token": str(self.access_token)}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_verify_refresh_success(self):
+        response = self.client.post(
+            reverse("auth:verify"), {"token": str(self.refresh_token)}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_verify_invalid_token(self):
+        response = self.client.post(
+            reverse("auth:verify"), {"token": str(self.access_token) + "0"}
+        )
+        self.assertContains(
+            response, "token_not_valid", status_code=status.HTTP_401_UNAUTHORIZED
+        )

--- a/cago-server/cago/user/tests/test_models.py
+++ b/cago-server/cago/user/tests/test_models.py
@@ -1,0 +1,51 @@
+from django.contrib.auth.hashers import check_password
+from django.test import TestCase
+
+from ..models import User
+
+
+class UserModelTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_email = "test1@test.com"
+        cls.user_password = "qwer1234"
+
+    def test_create_user_success(self):
+        user = User.objects.create_user(
+            email=self.user_email, password=self.user_password
+        )
+        self.assertEqual(user.email, self.user_email)
+        self.assertTrue(check_password(self.user_password, user.password))
+
+    def test_create_user_no_email(self):
+        with self.assertRaises(ValueError) as cm:
+            User.objects.create_user(email=None, password=self.user_password)
+        self.assertIn("email", str(cm.exception))
+
+    def test_create_superuser_success(self):
+        user = User.objects.create_superuser(
+            email=self.user_email, password=self.user_password
+        )
+        self.assertEqual(user.email, self.user_email)
+        self.assertTrue(check_password(self.user_password, user.password))
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+
+    def test_create_superuser_invalid_fields(self):
+        with self.assertRaises(ValueError) as cm:
+            User.objects.create_superuser(
+                email=self.user_email, password=self.user_password, is_staff=False
+            )
+        self.assertIn("is_staff", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            User.objects.create_superuser(
+                email=self.user_email, password=self.user_password, is_superuser=False
+            )
+        self.assertIn("is_superuser", str(cm.exception))
+
+    def test_clean(self):
+        email_denorm = self.user_email[:-3] + self.user_email[-3:].upper()
+        user = User.objects.create_user(email=email_denorm, password=self.user_password)
+        user.clean()
+        self.assertEqual(user.email, self.user_email)

--- a/cago-server/cago/user/urls.py
+++ b/cago-server/cago/user/urls.py
@@ -1,17 +1,12 @@
 from django.urls import path
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-    TokenVerifyView,
-)
 
 from . import views
 
 app_name = "user"
 
 urlpatterns = [
-    path("login/", TokenObtainPairView.as_view(), name="login"),
+    path("login/", views.LoginView.as_view(), name="login"),
     path("signup/", views.SignUpView.as_view(), name="signup"),
-    path("refresh/", TokenRefreshView.as_view(), name="refresh"),
-    path("verify/", TokenVerifyView.as_view(), name="verify"),
+    path("refresh/", views.CookieTokenRefreshView.as_view(), name="refresh"),
+    path("verify/", views.CookieTokenVerifyView.as_view(), name="verify"),
 ]

--- a/cago-server/cago/user/urls.py
+++ b/cago-server/cago/user/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
+
+app_name = "user"
+
+urlpatterns = [
+    path("login/", TokenObtainPairView.as_view(), name="login"),
+    path("refresh/", TokenRefreshView.as_view(), name="refresh"),
+    path("verify/", TokenVerifyView.as_view(), name="verify"),
+]

--- a/cago-server/cago/user/urls.py
+++ b/cago-server/cago/user/urls.py
@@ -5,10 +5,13 @@ from rest_framework_simplejwt.views import (
     TokenVerifyView,
 )
 
+from . import views
+
 app_name = "user"
 
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view(), name="login"),
+    path("signup/", views.SignUpView.as_view(), name="signup"),
     path("refresh/", TokenRefreshView.as_view(), name="refresh"),
     path("verify/", TokenVerifyView.as_view(), name="verify"),
 ]

--- a/cago-server/cago/user/views.py
+++ b/cago-server/cago/user/views.py
@@ -1,7 +1,31 @@
+from django.conf import settings
 from rest_framework import generics
 from rest_framework.permissions import AllowAny
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
 
 from cago.user.serializers import SignUpSerializer
+
+
+class LoginView(TokenObtainPairView):
+    def finalize_response(self, request, response, *args, **kwargs):
+        if response.data.get("refresh") is not None:
+            refresh = RefreshToken(response.data.get("refresh"))
+            max_age = refresh.get("exp") - refresh.get("iat")
+            response.set_cookie(
+                "refresh_token",
+                str(refresh),
+                max_age=max_age,
+                httponly=True,
+                secure=settings.SECURE_COOKIE,
+            )
+            del response.data["refresh"]
+
+        return super().finalize_response(request, response, *args, **kwargs)
 
 
 class SignUpView(generics.CreateAPIView):
@@ -10,3 +34,18 @@ class SignUpView(generics.CreateAPIView):
 
     def get_queryset(self):
         return None
+
+
+class CookieTokenRefreshView(TokenRefreshView):
+    def post(self, request, *args, **kwargs):
+        request.data["refresh"] = request.COOKIES.get("refresh_token")
+
+        return super().post(request, *args, **kwargs)
+
+
+class CookieTokenVerifyView(TokenVerifyView):
+    def post(self, request, *args, **kwargs):
+        if request.data.get("token") is None:
+            request.data["token"] = request.COOKIES.get("refresh_token")
+
+        return super().post(request, *args, **kwargs)

--- a/cago-server/cago/user/views.py
+++ b/cago-server/cago/user/views.py
@@ -1,3 +1,12 @@
-from django.shortcuts import render
+from rest_framework import generics
+from rest_framework.permissions import AllowAny
 
-# Create your views here.
+from cago.user.serializers import SignUpSerializer
+
+
+class SignUpView(generics.CreateAPIView):
+    permission_classes = [AllowAny]
+    serializer_class = SignUpSerializer
+
+    def get_queryset(self):
+        return None

--- a/cago-server/requirements.txt
+++ b/cago-server/requirements.txt
@@ -6,6 +6,7 @@ click==8.1.3
 coverage==6.5.0
 dill==0.3.6
 Django==4.1.2
+django-cors-headers==3.13.0
 django-extensions==3.2.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2

--- a/cago-server/requirements.txt
+++ b/cago-server/requirements.txt
@@ -7,6 +7,7 @@ dill==0.3.6
 Django==4.1.2
 django-extensions==3.2.1
 djangorestframework==3.14.0
+djangorestframework-simplejwt==5.2.2
 gunicorn==20.1.0
 isort==5.10.1
 lazy-object-proxy==1.7.1
@@ -15,6 +16,7 @@ mypy-extensions==0.4.3
 pathspec==0.10.1
 platformdirs==2.5.2
 psycopg2==2.9.4
+PyJWT==2.6.0
 pylint==2.15.5
 pylint-django==2.5.3
 pylint-plugin-utils==0.7

--- a/cago-server/requirements.txt
+++ b/cago-server/requirements.txt
@@ -11,6 +11,7 @@ django-extensions==3.2.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
 drf-spectacular==0.24.2
+drf-standardized-errors==0.12.2
 gunicorn==20.1.0
 inflection==0.5.1
 isort==5.10.1

--- a/cago-server/requirements.txt
+++ b/cago-server/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.5.2
 astroid==2.12.12
+attrs==22.1.0
 black==22.10.0
 click==8.1.3
 coverage==6.5.0
@@ -8,8 +9,11 @@ Django==4.1.2
 django-extensions==3.2.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
+drf-spectacular==0.24.2
 gunicorn==20.1.0
+inflection==0.5.1
 isort==5.10.1
+jsonschema==4.17.0
 lazy-object-proxy==1.7.1
 mccabe==0.7.0
 mypy-extensions==0.4.3
@@ -21,10 +25,13 @@ pylint==2.15.5
 pylint-django==2.5.3
 pylint-plugin-utils==0.7
 pyparsing==3.0.9
+pyrsistent==0.19.2
 python-decouple==3.6
 pytz==2022.5
+PyYAML==6.0
 sqlparse==0.4.3
 tomli==2.0.1
 tomlkit==0.11.5
 typing_extensions==4.4.0
+uritemplate==4.1.1
 wrapt==1.14.1


### PR DESCRIPTION
## APIs

- `POST /auth/signup/`
- `POST /auth/login/`
- `POST /auth/verify/` - access/refresh token 확인
- `POST /auth/refresh/` - access token 재발급

JWT를 사용하면 `/auth/logout`은 당장 필요가 없다고 판단해 구현하지 않았습니다. 보안을 위해 refresh token은 http only 쿠키에 저장하는 방식으로 변경했습니다. 따라서 `refresh_token`은 body가 아니라 쿠키에 위치합니다. 인증은 `Authorization` 헤더에 access token을 넣는 식으로 이루어집니다. 

## Packages

- `djangorestframework-simplejwt` - JWT 관련
- `drf-spectacular` - API 문서 자동화
- `django-cors-headers` - CORS 헤더 설정
- `drf-standardized-errors` - 에러 핸들러

초기 세팅이 덜 끝났다보니 이 브랜치에서 몇가지 패키지를 추가로 설치했습니다
