### PR TITLE
[Web] Replace Require* Hooks With Components

### DIFF
--- a/cago-web/src/components/layouts/RequireLogin.tsx
+++ b/cago-web/src/components/layouts/RequireLogin.tsx
@@ -1,0 +1,28 @@
+import { useAuth } from "lib/auth";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+const RequireLogin = ({ children }: Props) => {
+  const { loading, loggedIn } = useAuth();
+
+  const router = useRouter();
+  const redirect = "/auth/login";
+
+  useEffect(() => {
+    router.prefetch(redirect);
+
+    if (!loading && !loggedIn) {
+      // Redirect while setting the current path as a query parameter.
+      router.replace({ pathname: redirect, query: { redirect: router.pathname } });
+    }
+  }, [loading, loggedIn, router]);
+
+  // Prevent rendering the children while not logged in.
+  return <>{loggedIn && children}</>;
+};
+
+export default RequireLogin;

--- a/cago-web/src/components/layouts/RequireLogout.tsx
+++ b/cago-web/src/components/layouts/RequireLogout.tsx
@@ -1,0 +1,29 @@
+import { useAuth } from "lib/auth";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+const RequireLogout = ({ children }: Props) => {
+  const { loading, loggedIn } = useAuth();
+
+  const router = useRouter();
+
+  // Redirect path should be in the query parameters. Fallback is index page.
+  const redirect = (router.query.redirect as string | undefined) ?? "/";
+
+  useEffect(() => {
+    router.prefetch(redirect);
+
+    if (loggedIn) {
+      router.replace(redirect);
+    }
+  }, [loggedIn, redirect, router]);
+
+  // Prevent rendering the children while loading or logged in.
+  return <>{!loading && !loggedIn && children}</>;
+};
+
+export default RequireLogout;

--- a/cago-web/src/lib/auth.ts
+++ b/cago-web/src/lib/auth.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError } from "axios";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { CagoAPIError, getCagoRequest } from "utils";
@@ -103,36 +102,4 @@ export const useAuth = () => {
   }, [data, mutate]);
 
   return { loading, loggedIn, user };
-};
-
-/**
- * Redirect to the url if the user is logged out.
- */
-export const useRequireLogin = (url: string) => {
-  const { loading, loggedIn } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    router.prefetch(url);
-
-    if (!loading && !loggedIn) {
-      router.replace(url);
-    }
-  }, [loading, loggedIn, url, router]);
-};
-
-/**
- * Redirect to the url if the user is logged in.
- */
-export const useRequireLogout = (url: string) => {
-  const { loggedIn } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    router.prefetch(url);
-
-    if (loggedIn) {
-      router.replace(url);
-    }
-  }, [loggedIn, url, router]);
 };

--- a/cago-web/src/pages/auth/login.tsx
+++ b/cago-web/src/pages/auth/login.tsx
@@ -1,14 +1,12 @@
 import LoginForm from "components/forms/LoginForm";
 import Container from "components/layouts/Container";
-import { useRequireLogout } from "lib/auth";
+import RequireLogout from "components/layouts/RequireLogout";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { NextPageWithLayout } from "pages/_app";
 
 const Login: NextPageWithLayout = () => {
   const router = useRouter();
-  const redirect = (router.query?.redirect as string) || "/cafes";
-  useRequireLogout(redirect);
 
   return (
     <main className="flex flex-col h-screen items-center justify-center">
@@ -18,7 +16,7 @@ const Login: NextPageWithLayout = () => {
           <LoginForm />
         </div>
         <Link
-          href={{ pathname: "/auth/signup", query: { redirect } }}
+          href={{ pathname: "/auth/signup", query: router.query }}
           className="block w-fit ml-auto underline underline-offset-2"
         >
           회원가입
@@ -28,6 +26,10 @@ const Login: NextPageWithLayout = () => {
   );
 };
 
-Login.getLayout = (page) => <Container>{page}</Container>;
+Login.getLayout = (page) => (
+  <RequireLogout>
+    <Container>{page}</Container>
+  </RequireLogout>
+);
 
 export default Login;

--- a/cago-web/src/pages/auth/signup.tsx
+++ b/cago-web/src/pages/auth/signup.tsx
@@ -1,14 +1,9 @@
 import SignUpForm from "components/forms/SignUpForm";
 import Container from "components/layouts/Container";
-import { useRequireLogout } from "lib/auth";
-import { useRouter } from "next/router";
+import RequireLogout from "components/layouts/RequireLogout";
 import { NextPageWithLayout } from "pages/_app";
 
 const SignUp: NextPageWithLayout = () => {
-  const router = useRouter();
-  const redirect = (router.query?.redirect as string) || "/cafes";
-  useRequireLogout(redirect);
-
   return (
     <main className="flex flex-col h-screen items-center justify-center">
       <h1 className="font-bold text-4xl mb-8">Welcome to Cago!</h1>
@@ -21,6 +16,10 @@ const SignUp: NextPageWithLayout = () => {
   );
 };
 
-SignUp.getLayout = (page) => <Container>{page}</Container>;
+SignUp.getLayout = (page) => (
+  <RequireLogout>
+    <Container>{page}</Container>;
+  </RequireLogout>
+);
 
 export default SignUp;


### PR DESCRIPTION
`lib/auth.ts`에 있던 `useRequireLogin`과 `useRequireLogout`을 제거하고 layouts에 컴포넌트로 만들었습니다. 페이지를 children로 넘기면 조건부로 렌더링합니다.