### PR TITLE
[Web] RequireManager

### DIFF
--- a/cago-web/src/components/layouts/RequireManager.tsx
+++ b/cago-web/src/components/layouts/RequireManager.tsx
@@ -1,0 +1,35 @@
+import { useAuth } from "lib/auth";
+import { useCafe } from "lib/cafe";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+const RequireManager = ({ children }: Props) => {
+  const { user } = useAuth();
+
+  const router = useRouter();
+  const { cafe_id } = router.query;
+  const { data: cafe } = useCafe(cafe_id);
+
+  const redirect = "/admin/dashboard";
+  const is_manager = user && cafe?.is_managed && cafe.managers.includes(user.id);
+
+  useEffect(() => {
+    router.prefetch(redirect);
+
+    // Replace to dashboard page if the user is not a manager.
+    if (user && cafe?.is_managed) {
+      if (!cafe.managers.includes(user.id)) {
+        router.replace({ pathname: redirect });
+      }
+    }
+  }, [router, user, cafe]);
+
+  // Prevent rendering the children while validating.
+  return <>{is_manager && children}</>;
+};
+
+export default RequireManager;

--- a/cago-web/src/pages/admin/dashboard/[cafe_id]/index.tsx
+++ b/cago-web/src/pages/admin/dashboard/[cafe_id]/index.tsx
@@ -3,6 +3,7 @@ import { ManagedCafe } from "components/contents/CafesMap";
 import CagoAdminHeader from "components/layouts/CagoAdminHeader";
 import Container from "components/layouts/Container";
 import RequireLogin from "components/layouts/RequireLogin";
+import RequireManager from "components/layouts/RequireManager";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { NextPageWithLayout } from "pages/_app";
@@ -63,8 +64,10 @@ const DashboardDetail: NextPageWithLayout = () => {
 
 DashboardDetail.getLayout = (page) => (
   <RequireLogin>
-    <CagoAdminHeader />
-    <Container>{page}</Container>
+    <RequireManager>
+      <CagoAdminHeader />
+      <Container>{page}</Container>
+    </RequireManager>
   </RequireLogin>
 );
 

--- a/cago-web/src/tests/components/layouts/RequireManager.test.tsx
+++ b/cago-web/src/tests/components/layouts/RequireManager.test.tsx
@@ -1,0 +1,76 @@
+import RequireManager from "components/layouts/RequireManager";
+import { server } from "mocks/server";
+import { cafes } from "mocks/stubs";
+import { rest } from "msw";
+import { replace } from "tests/mocks";
+import { act, render, screen } from "tests/utils";
+
+// A child component to render
+const child = <div data-testid="child" />;
+
+describe("require manager", () => {
+  describe("if the user is not logged in", () => {
+    beforeEach(() => {
+      server.use(
+        rest.post("/auth/refresh/", (req, res, ctx) => {
+          return res(ctx.status(401));
+        })
+      );
+    });
+
+    it("does not redirect", async () => {
+      await act(() => {
+        render(<RequireManager>{child}</RequireManager>);
+      });
+      expect(replace).not.toBeCalled();
+    });
+
+    it("does not render children", async () => {
+      await act(() => {
+        render(<RequireManager>{child}</RequireManager>);
+      });
+      expect(screen.queryByTestId("child")).toBeNull();
+    });
+  });
+
+  describe("if the user is logged in", () => {
+    describe("if the user is manager", () => {
+      it("does not redirect", async () => {
+        await act(() => {
+          render(<RequireManager>{child}</RequireManager>);
+        });
+        expect(replace).not.toBeCalled();
+      });
+
+      it("renders children", async () => {
+        render(<RequireManager>{child}</RequireManager>);
+        await screen.findByTestId("child");
+      });
+    });
+
+    describe("if the user is not a manager", () => {
+      const stubCafe = { ...cafes[0], managers: [99] };
+      beforeEach(() => {
+        server.use(
+          rest.get("/cafes/1/", (req, res, ctx) => {
+            return res(ctx.json(stubCafe));
+          })
+        );
+      });
+
+      it("redirect to dashboard", async () => {
+        await act(() => {
+          render(<RequireManager>{child}</RequireManager>);
+        });
+        expect(replace).toBeCalled();
+      });
+
+      it("does not render children", async () => {
+        await act(() => {
+          render(<RequireManager>{child}</RequireManager>);
+        });
+        expect(screen.queryByTestId("child")).toBeNull();
+      });
+    });
+  });
+});


### PR DESCRIPTION
`RequireManager` component

- Redirect to '/admin/dashboard' only if the user is logged in and not a manager. Generally, should be used together with `RequireLogin`.
- In the future, `RequireManager` would be used in all the pages under /admin/dashboard/[cafe_id] directory.