### PR TITLE
[Web] Menu Pages

### DIFF
--- a/cago-web/next.config.js
+++ b/cago-web/next.config.js
@@ -43,6 +43,11 @@ const nextConfig = {
       },
       {
         protocol: "https",
+        hostname: "cdn4.iconfinder.com",
+        pathname: "/data/icons/**",
+      },
+      {
+        protocol: "https",
         hostname: "live.staticflickr.com",
         pathname: "/**",
       },

--- a/cago-web/src/components/contents/CafeMenuContainer.tsx
+++ b/cago-web/src/components/contents/CafeMenuContainer.tsx
@@ -1,0 +1,35 @@
+import { Menu } from "lib/menu";
+import Image from "next/image";
+
+interface Props {
+  category: string;
+  menuList: Menu[];
+  editable?: boolean;
+}
+
+const CafeMenuCard = ({ name, price, image }: Pick<Menu, "name" | "price" | "image">) => {
+  return (
+    <div className="text-center p-4 shadow-xl rounded-lg w-48 h-fit hover:scale-105 transition-transform">
+      <Image src={image} alt="cafe-menu" width={160} height={160} className="mb-2" />
+      <h5 className="font-semibold text-lg">{name}</h5>
+      <h5>{price}원</h5>
+    </div>
+  );
+};
+
+const CafeMenuContainer = ({ category, menuList, editable }: Props) => {
+  return (
+    <div>
+      <h2 className="font-bold text-2xl mb-1">{category}</h2>
+      <hr className="mb-3 border-t-slate-300" />
+      <div className="flex flex-wrap gap-4 md:justify-start justify-center">
+        {menuList.map((menu) => (
+          <CafeMenuCard key={menu.id} name={menu.name} price={menu.price} image={menu.image} />
+        ))}
+        {menuList.length === 0 && <h4>메뉴가 없습니다!</h4>}
+      </div>
+    </div>
+  );
+};
+
+export default CafeMenuContainer;

--- a/cago-web/src/components/contents/CafeMenuContainer.tsx
+++ b/cago-web/src/components/contents/CafeMenuContainer.tsx
@@ -1,30 +1,74 @@
-import { Menu } from "lib/menu";
+import { useAuth } from "lib/auth";
+import { deleteMenu, Menu } from "lib/menu";
 import Image from "next/image";
 
-interface Props {
+interface ReadOnlyProps {
   category: string;
   menuList: Menu[];
-  editable?: boolean;
+  editable?: false;
 }
 
-const CafeMenuCard = ({ name, price, image }: Pick<Menu, "name" | "price" | "image">) => {
+interface EditableProps extends Omit<ReadOnlyProps, "editable"> {
+  editable: true;
+  cafeId: number;
+}
+
+interface CardProps {
+  name: string;
+  price: number;
+  image: string;
+  editable?: boolean;
+  onDelete?: () => void;
+}
+
+const CafeMenuCard = (props: CardProps) => {
+  const { name, price, image } = props;
+
   return (
-    <div className="text-center p-4 shadow-xl rounded-lg w-48 h-fit hover:scale-105 transition-transform">
+    <div className="relative text-center p-4 shadow-xl rounded-lg w-48 h-fit hover:scale-105 transition-transform">
       <Image src={image} alt="cafe-menu" width={160} height={160} className="mb-2" />
       <h5 className="font-semibold text-lg">{name}</h5>
       <h5>{price}원</h5>
+
+      {/* Display delete button on top-right corner, if editable. */}
+      {props.editable && (
+        <button
+          className="absolute top-0 right-0 p-2 leading-4 text-red-700 z-50"
+          onClick={(e) => {
+            props.onDelete?.();
+          }}
+        >
+          ✖
+        </button>
+      )}
     </div>
   );
 };
 
-const CafeMenuContainer = ({ category, menuList, editable }: Props) => {
+const CafeMenuContainer = (props: ReadOnlyProps | EditableProps) => {
+  const { category, menuList, editable } = props;
+  const { user } = useAuth();
+
+  const handleDelete = async (menuId: number) => {
+    if (user && editable) {
+      await deleteMenu(props.cafeId, menuId, user.token);
+    }
+  };
+
   return (
     <div>
       <h2 className="font-bold text-2xl mb-1">{category}</h2>
       <hr className="mb-3 border-t-slate-300" />
       <div className="flex flex-wrap gap-4 md:justify-start justify-center">
         {menuList.map((menu) => (
-          <CafeMenuCard key={menu.id} name={menu.name} price={menu.price} image={menu.image} />
+          <CafeMenuCard
+            key={menu.id}
+            name={menu.name}
+            price={menu.price}
+            image={menu.image}
+            editable={editable}
+            onDelete={() => handleDelete(menu.id)}
+          />
         ))}
         {menuList.length === 0 && <h4>메뉴가 없습니다!</h4>}
       </div>

--- a/cago-web/src/components/forms/CreateMenuForm.tsx
+++ b/cago-web/src/components/forms/CreateMenuForm.tsx
@@ -1,0 +1,100 @@
+import { useAuth } from "lib/auth";
+import { createMenu } from "lib/menu";
+import React, { useState } from "react";
+
+interface Props {
+  cafeId: number;
+  onSuccess?: () => void;
+}
+
+const CreateMenuForm = (props: Props) => {
+  const [name, setName] = useState<string>("");
+  const [category, setCategory] = useState<string>("");
+  const [price, setPrice] = useState<number | "">("");
+  const [isMain, setIsMain] = useState<boolean>(false);
+
+  const { user } = useAuth();
+
+  const handleSubmit: React.FormEventHandler = async (e) => {
+    e.preventDefault();
+
+    try {
+      if (user) {
+        const data = {
+          cafe: props.cafeId,
+          name,
+          is_main: isMain,
+          category,
+          price: price === "" ? 0 : price,
+          image: "https://cdn4.iconfinder.com/data/icons/sketchy-basic-icons/94/coffee-512.png", // TODO: upload image
+        };
+        await createMenu(data, user.token);
+        props.onSuccess?.();
+      }
+    } catch (e) {
+      const error = e as Error;
+      window.alert(error.message);
+    }
+  };
+
+  return (
+    // TODO: upload image
+    <form className="flex flex-col" onSubmit={(e) => handleSubmit(e)}>
+      {/* Menu name */}
+      <input
+        type="text"
+        aria-label="menu-name"
+        placeholder="메뉴 이름"
+        required
+        autoFocus
+        onChange={(e) => setName(e.target.value)}
+        className="outlined font-normal mb-2"
+      />
+
+      {/* Menu category */}
+      <input
+        type="text"
+        aria-label="menu-category"
+        placeholder="카테고리"
+        required
+        onChange={(e) => setCategory(e.target.value)}
+        className="outlined font-normal mb-2"
+      />
+
+      {/* Menu price */}
+      <input
+        type="text"
+        aria-label="menu-price"
+        placeholder="가격"
+        required
+        value={price}
+        onChange={(e) => {
+          if (e.target.value === "") {
+            setPrice("");
+          } else if (!isNaN(e.target.value as any)) {
+            setPrice(parseInt(e.target.value));
+          }
+        }}
+        className="outlined font-normal mb-2 appearance-none"
+      />
+
+      {/* Menu is main checkbox */}
+      <label>
+        메인 메뉴입니까?
+        <input
+          type="checkbox"
+          aria-label="menu-is-main"
+          className="ml-2"
+          onChange={(e) => setIsMain(e.target.checked)}
+        />
+      </label>
+
+      {/* Submit button */}
+      <button type="submit" className="contained mt-4">
+        추가하기
+      </button>
+    </form>
+  );
+};
+
+export default CreateMenuForm;

--- a/cago-web/src/lib/menu.ts
+++ b/cago-web/src/lib/menu.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import useSWR from "swr";
+import { getCagoRequest } from "utils";
+
+export interface Menu {
+  id: number;
+  cafe: number;
+  name: string;
+  is_main: boolean;
+  category: string;
+  price: number;
+  image: string;
+}
+
+export interface CategorizedMenu {
+  category: string;
+  menuList: Menu[];
+}
+
+export const useMenu = (cafeId: string | string[] | undefined) => {
+  const { data } = useSWR<Menu[]>(cafeId && `/menus/?cafe_id=${cafeId}`, getCagoRequest());
+
+  // Get the categories.
+  const categories = useMemo(() => {
+    if (data) {
+      const set = new Set(data.map((item) => item.category));
+      return Array.from(set);
+    } else {
+      return [];
+    }
+  }, [data]);
+
+  // Get the main menus.
+  const mainMenuList = useMemo(() => {
+    if (data) {
+      return data.filter((item) => item.is_main);
+    } else {
+      return [];
+    }
+  }, [data]);
+
+  // Get the list of menu formatted with the categories.
+  const categorizedMenuList: CategorizedMenu[] = useMemo(() => {
+    if (data && categories) {
+      return categories.map((category) => {
+        const menuList = data.filter((item) => item.category === category);
+        return { category, menuList };
+      });
+    } else {
+      return [];
+    }
+  }, [data, categories]);
+
+  return { categories, mainMenuList, categorizedMenuList };
+};

--- a/cago-web/src/lib/menu.ts
+++ b/cago-web/src/lib/menu.ts
@@ -22,6 +22,11 @@ export const createMenu = async (data: Omit<Menu, "id">, token: string) => {
   mutate(`/menus/?cafe_id=${data.cafe}`);
 };
 
+export const deleteMenu = async (cafeId: number, menuId: number, token: string) => {
+  await getCagoRequest("delete", token)(`/menus/${menuId}/`);
+  mutate(`/menus/?cafe_id=${cafeId}`);
+};
+
 export const useMenu = (cafeId: string | string[] | undefined) => {
   const { data } = useSWR<Menu[]>(cafeId && `/menus/?cafe_id=${cafeId}`, getCagoRequest());
 

--- a/cago-web/src/lib/menu.ts
+++ b/cago-web/src/lib/menu.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import { getCagoRequest } from "utils";
 
 export interface Menu {
@@ -16,6 +16,11 @@ export interface CategorizedMenu {
   category: string;
   menuList: Menu[];
 }
+
+export const createMenu = async (data: Omit<Menu, "id">, token: string) => {
+  await getCagoRequest("post", token)("/menus/", data);
+  mutate(`/menus/?cafe_id=${data.cafe}`);
+};
 
 export const useMenu = (cafeId: string | string[] | undefined) => {
   const { data } = useSWR<Menu[]>(cafeId && `/menus/?cafe_id=${cafeId}`, getCagoRequest());

--- a/cago-web/src/mocks/handlers.ts
+++ b/cago-web/src/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { rest } from "msw";
-import { cafes, profile, token, user } from "./stubs";
+import { cafes, cafe_menu, profile, token, user } from "./stubs";
 
 // Simplest API handlers
 export const handlers = [
@@ -64,5 +64,17 @@ export const handlers = [
 
   rest.post("/cafes/", (req, res, ctx) => {
     return res(ctx.status(201), ctx.json(cafes[0]));
+  }),
+
+  rest.get("/menus/", (req, res, ctx) => {
+    return res(ctx.json(cafe_menu));
+  }),
+
+  rest.delete("/menus/1/", (req, res, ctx) => {
+    return res(ctx.status(204));
+  }),
+
+  rest.post("/menus/", (req, res, ctx) => {
+    return res(ctx.status(201), ctx.json(cafe_menu[0]));
   }),
 ];

--- a/cago-web/src/mocks/stubs.ts
+++ b/cago-web/src/mocks/stubs.ts
@@ -43,3 +43,33 @@ export const cafes = [
     address: "address2",
   },
 ];
+
+export const cafe_menu = [
+  {
+    id: 1,
+    cafe: 1,
+    name: "아메리카노",
+    is_main: true,
+    category: "커피",
+    price: "5000",
+    image: "https://cdn4.iconfinder.com/data/icons/sketchy-basic-icons/94/coffee-512.png",
+  },
+  {
+    id: 2,
+    cafe: 1,
+    name: "카페라떼",
+    is_main: false,
+    category: "커피",
+    price: "6000",
+    image: "https://cdn4.iconfinder.com/data/icons/sketchy-basic-icons/94/coffee-512.png",
+  },
+  {
+    id: 3,
+    cafe: 1,
+    name: "치크 케이크",
+    is_main: true,
+    category: "케이크",
+    price: "10000",
+    image: "https://cdn4.iconfinder.com/data/icons/sketchy-basic-icons/94/coffee-512.png",
+  },
+];

--- a/cago-web/src/pages/admin/dashboard/[cafe_id]/index.tsx
+++ b/cago-web/src/pages/admin/dashboard/[cafe_id]/index.tsx
@@ -44,16 +44,16 @@ const DashboardDetail: NextPageWithLayout = () => {
           <CafeInfoContainer title="카페 사진" path={`/admin/dashboard/${cafe_id}/add-pictures`}>
             {"TODO: picture"}
           </CafeInfoContainer>
-          <CafeInfoContainer title="카페 소개" path={`/admin/dashboard/${cafe_id}/add-pictures`}>
+          <CafeInfoContainer title="카페 소개" path={`/admin/dashboard/${cafe_id}/info`}>
             {cafe.introduction ?? "카페 소개를 작성해보세요!"}
           </CafeInfoContainer>
-          <CafeInfoContainer title="공지사항" path={`/admin/dashboard/${cafe_id}/add-pictures`}>
+          <CafeInfoContainer title="공지사항" path={`/admin/dashboard/${cafe_id}/board`}>
             {"TODO: board"}
           </CafeInfoContainer>
-          <CafeInfoContainer title="리뷰" path={`/admin/dashboard/${cafe_id}/add-pictures`}>
+          <CafeInfoContainer title="리뷰" path={`/admin/dashboard/${cafe_id}/reviews`}>
             {"TODO: review"}
           </CafeInfoContainer>
-          <CafeInfoContainer title="메뉴" path={`/admin/dashboard/${cafe_id}/add-pictures`}>
+          <CafeInfoContainer title="메뉴" path={`/admin/dashboard/${cafe_id}/menu`}>
             {"TODO: menu"}
           </CafeInfoContainer>
         </div>

--- a/cago-web/src/pages/admin/dashboard/[cafe_id]/menu.tsx
+++ b/cago-web/src/pages/admin/dashboard/[cafe_id]/menu.tsx
@@ -1,0 +1,70 @@
+import CafeMenuContainer from "components/contents/CafeMenuContainer";
+import CreateMenuForm from "components/forms/CreateMenuForm";
+import CagoAdminHeader from "components/layouts/CagoAdminHeader";
+import Container from "components/layouts/Container";
+import RequireLogin from "components/layouts/RequireLogin";
+import RequireManager from "components/layouts/RequireManager";
+import { useMenu } from "lib/menu";
+import { useRouter } from "next/router";
+import { NextPageWithLayout } from "pages/_app";
+import { useState } from "react";
+
+const DashboardMenu: NextPageWithLayout = () => {
+  const router = useRouter();
+  const { cafe_id } = router.query;
+  const { mainMenuList, categorizedMenuList } = useMenu(cafe_id);
+
+  const cafeId = parseInt(cafe_id as any);
+
+  const [showAddMenuModal, setShowAddMenuModal] = useState<boolean>(false);
+
+  return (
+    <main>
+      {/* Add menu button */}
+      <div className="w-full text-right mt-8 mb-2">
+        <button className="contained" onClick={(e) => setShowAddMenuModal(true)}>
+          메뉴 추가하기
+        </button>
+      </div>
+
+      {/* Main menu */}
+      <div className="mb-8">
+        <CafeMenuContainer category="대표 메뉴" menuList={mainMenuList} editable cafeId={cafeId} />
+      </div>
+
+      {/* Categorized menu */}
+      {categorizedMenuList.map((list) => (
+        <div key={list.category} className="mb-8">
+          <CafeMenuContainer category={list.category} menuList={list.menuList} editable cafeId={cafeId} />
+        </div>
+      ))}
+
+      {/* Modal to add a menu */}
+      {showAddMenuModal && (
+        <>
+          <div className="p-6 absolute bottom-1/2 translate-y-1/2 right-1/2 translate-x-1/2 bg-slate-50 shadow-lg rounded-lg z-50">
+            <CreateMenuForm cafeId={cafeId} onSuccess={() => setShowAddMenuModal(false)} />
+          </div>
+
+          {/* Below overlaps the entire screen, and close the model if clicked. */}
+          <div
+            data-testid="modal-overlay"
+            className="opacity-50 backdrop-brightness-50 fixed top-0 bottom-0 left-0 right-0"
+            onClick={(e) => setShowAddMenuModal(false)}
+          />
+        </>
+      )}
+    </main>
+  );
+};
+
+DashboardMenu.getLayout = (page) => (
+  <RequireLogin>
+    <RequireManager>
+      <CagoAdminHeader />
+      <Container>{page}</Container>
+    </RequireManager>
+  </RequireLogin>
+);
+
+export default DashboardMenu;

--- a/cago-web/src/pages/cafes/[cafe_id]/menu.tsx
+++ b/cago-web/src/pages/cafes/[cafe_id]/menu.tsx
@@ -1,0 +1,38 @@
+import CafeMenuContainer from "components/contents/CafeMenuContainer";
+import CagoHeader from "components/layouts/CagoHeader";
+import Container from "components/layouts/Container";
+import RequireProfile from "components/layouts/RequireProfile";
+import { useMenu } from "lib/menu";
+import { useRouter } from "next/router";
+import { NextPageWithLayout } from "pages/_app";
+
+const CafeMenu: NextPageWithLayout = () => {
+  const router = useRouter();
+  const { cafe_id } = router.query;
+  const { mainMenuList, categorizedMenuList } = useMenu(cafe_id);
+
+  return (
+    <main>
+      {/* Main menu */}
+      <div className="my-8">
+        <CafeMenuContainer category="대표 메뉴" menuList={mainMenuList} />
+      </div>
+
+      {/* Categorized menu */}
+      {categorizedMenuList.map((list) => (
+        <div key={list.category} className="mb-8">
+          <CafeMenuContainer category={list.category} menuList={list.menuList} />
+        </div>
+      ))}
+    </main>
+  );
+};
+
+CafeMenu.getLayout = (page) => (
+  <RequireProfile>
+    <CagoHeader />
+    <Container>{page}</Container>
+  </RequireProfile>
+);
+
+export default CafeMenu;

--- a/cago-web/src/tests/components/contents/CafeMenuContainer.test.tsx
+++ b/cago-web/src/tests/components/contents/CafeMenuContainer.test.tsx
@@ -1,0 +1,35 @@
+import userEvent from "@testing-library/user-event";
+import CafeMenuContainer from "components/contents/CafeMenuContainer";
+import { cafe_menu } from "mocks/stubs";
+import { act, render, screen } from "tests/utils";
+
+const categoryStub = "커피";
+const menuListStub: any = [cafe_menu[0], cafe_menu[1]];
+
+describe("cafe menu container", () => {
+  describe("read only", () => {
+    it("renders category name", async () => {
+      await act(() => {
+        render(<CafeMenuContainer category={categoryStub} menuList={menuListStub} />);
+      });
+      expect(screen.getByText(categoryStub)).toBeVisible();
+    });
+
+    it("renders menu", async () => {
+      await act(() => {
+        render(<CafeMenuContainer category={categoryStub} menuList={menuListStub} />);
+      });
+      expect(screen.getByText(menuListStub[0].name)).toBeVisible();
+    });
+  });
+
+  describe("editable", () => {
+    it("is able to delete a menu", async () => {
+      await act(() => {
+        render(<CafeMenuContainer category={categoryStub} menuList={menuListStub} editable cafeId={1} />);
+      });
+      const button = screen.getAllByRole("button", { name: /✖/ })[0];
+      await userEvent.click(button);
+    });
+  });
+});

--- a/cago-web/src/tests/components/forms/CreateMenuForm.test.tsx
+++ b/cago-web/src/tests/components/forms/CreateMenuForm.test.tsx
@@ -1,0 +1,28 @@
+import userEvent from "@testing-library/user-event";
+import CreateMenuForm from "components/forms/CreateMenuForm";
+import { act } from "react-dom/test-utils";
+import { render, screen } from "tests/utils";
+
+describe("create menu form", () => {
+  it("handles creating a menu", async () => {
+    const onSuccess = jest.fn();
+
+    await act(() => {
+      render(<CreateMenuForm cafeId={1} onSuccess={onSuccess} />);
+    });
+
+    const nameInput = screen.getByPlaceholderText(/이름/);
+    const categoryInput = screen.getByPlaceholderText(/카테고리/);
+    const priceInput = screen.getByPlaceholderText(/가격/);
+    const checkbox = screen.getByRole("checkbox");
+
+    await userEvent.type(nameInput, "카라멜 마키야토");
+    await userEvent.type(categoryInput, "커피");
+    await userEvent.type(priceInput, "7000");
+    await userEvent.click(checkbox);
+
+    const button = screen.getByRole("button", { name: /추가하기/ });
+    await userEvent.click(button);
+    expect(onSuccess).toBeCalledTimes(1);
+  });
+});

--- a/cago-web/src/tests/pages/admin/dashboard/[cafe_id]/menu.test.tsx
+++ b/cago-web/src/tests/pages/admin/dashboard/[cafe_id]/menu.test.tsx
@@ -1,0 +1,21 @@
+import userEvent from "@testing-library/user-event";
+import DashboardMenu from "pages/admin/dashboard/[cafe_id]/menu";
+import { act, render, screen } from "tests/utils";
+
+describe("admin dashboard menu page", () => {
+  it("renders", async () => {
+    await act(() => {
+      render(<DashboardMenu />);
+    });
+  });
+
+  it("displays add menu button", async () => {
+    await act(() => {
+      render(<DashboardMenu />);
+    });
+    const button = await screen.findByRole("button", { name: /추가하기/ });
+    await userEvent.click(button); // open modal
+    screen.getByPlaceholderText(/메뉴 이름/);
+    await userEvent.click(await screen.findByTestId(/modal-overlay/)); // close modal
+  });
+});

--- a/cago-web/src/tests/pages/cafes/[cafe_id]/menu.test.tsx
+++ b/cago-web/src/tests/pages/cafes/[cafe_id]/menu.test.tsx
@@ -1,0 +1,17 @@
+import CafeMenu from "pages/cafes/[cafe_id]/menu";
+import { act, render, screen } from "tests/utils";
+
+describe("cafe menu page", () => {
+  it("renders", async () => {
+    await act(() => {
+      render(<CafeMenu />);
+    });
+  });
+
+  it("displays main menu", async () => {
+    await act(() => {
+      render(<CafeMenu />);
+    });
+    expect(await screen.findByText(/대표 메뉴/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
- /cafes/{cafe_id}/menu
  - `CafeMenuContainer`의 editable=false
- /admin/dashboard/{cafe_id}/menu
  - `CafeMenuContainer`의 editable=true
  - 메뉴를 수정하는 UI는 만들지 않았습니다. 일단 기능상으로는 추가/삭제로 대체할 수 있으니 일단 이 상태로 놔두겠습니다.

`useMenu` 훅에서는 API로부터 받아온 카페 리스트를 카테고리, 대표 여부를 기준으로 정리합니다.
