### PR TITLE
[Server] Like APIs

### DIFF
--- a/cago-server/cago/cafe/serializers.py
+++ b/cago-server/cago/cafe/serializers.py
@@ -96,12 +96,6 @@ class CafeReadOnlySerializer(ReadOnlyModelSerializer):
 
 
 class ManagedCafeSerializer(serializers.ModelSerializer):
-    num_likes = serializers.IntegerField(read_only=True)
-    num_reviews = serializers.IntegerField(read_only=True)
-    num_taste = serializers.IntegerField(read_only=True)
-    num_service = serializers.IntegerField(read_only=True)
-    num_mood = serializers.IntegerField(read_only=True)
-
     class Meta:
         model = ManagedCafe
         fields = [  # Exclude liked_users
@@ -117,11 +111,6 @@ class ManagedCafeSerializer(serializers.ModelSerializer):
             "avatar",
             "force_closed",
             "crowdedness",
-            "num_likes",
-            "num_reviews",
-            "num_taste",
-            "num_service",
-            "num_mood",
         ]
         read_only_fields = ["owner", "managers"]
         extra_kwargs = {"location": {"required": True}}

--- a/cago-server/cago/cafe/serializers.py
+++ b/cago-server/cago/cafe/serializers.py
@@ -30,6 +30,7 @@ class CustomerProfileSerializer(serializers.ModelSerializer):
 
 
 class ManagedCafeReadOnlySerializer(ReadOnlyModelSerializer):
+    is_liked: bool = serializers.SerializerMethodField()
     num_likes = serializers.IntegerField(read_only=True)
     num_reviews = serializers.IntegerField(read_only=True)
     num_taste = serializers.IntegerField(read_only=True)
@@ -51,12 +52,20 @@ class ManagedCafeReadOnlySerializer(ReadOnlyModelSerializer):
             "avatar",
             "force_closed",
             "crowdedness",
+            "is_liked",
             "num_likes",
             "num_reviews",
             "num_taste",
             "num_service",
             "num_mood",
         ]
+
+    def get_is_liked(self, obj):
+        user = self.context["request"].user
+        if user is None:
+            return False
+
+        return obj.liked_users.filter(id=user.id).exists()
 
 
 class CafeReadOnlySerializer(ReadOnlyModelSerializer):

--- a/cago-server/cago/cafe/tests/test_api_like.py
+++ b/cago-server/cago/cafe/tests/test_api_like.py
@@ -1,0 +1,55 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from ..models import Cafe, CafeMenu, ManagedCafe
+from ..utils import parse_coordinate
+
+User = get_user_model()
+
+user_data = {
+    "email": "test1@test.com",
+    "password": "qwer1234",
+}
+
+cafe_data = {
+    "name": "이상한 카페",
+    "phone_number": "+821012345678",
+    "location": parse_coordinate("127.000304 37.475322"),
+    "address": "서울특별시 서초구 방배로 21",
+    "registration_number": 1234567890,
+    "owner": None,
+}
+
+
+class CafeLikeAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(**user_data)
+        cls.cafe_data = cafe_data.copy()
+        cls.cafe_data["owner"] = cls.user
+        cls.cafe = ManagedCafe.objects.create(**cls.cafe_data)
+
+    def setUp(self):
+        self.client.force_authenticate(self.user)
+
+    def test_like_create_success(self):
+        response = self.client.post(reverse("like"), {"cafe": self.cafe.id})
+        self.assertContains(response, "", status_code=status.HTTP_201_CREATED)
+
+    def test_like_delete_success(self):
+        response = self.client.delete(reverse("like"), {"cafe": self.cafe.id})
+        self.assertContains(response, "", status_code=status.HTTP_204_NO_CONTENT)
+
+    def test_like_create_no_cafe_id(self):
+        response = self.client.post(reverse("like"), {})
+        self.assertContains(
+            response, "invalid", status_code=status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_like_delete_no_cafe_id(self):
+        response = self.client.delete(reverse("like"), {})
+        self.assertContains(
+            response, "invalid", status_code=status.HTTP_400_BAD_REQUEST
+        )

--- a/cago-server/cago/cafe/urls.py
+++ b/cago-server/cago/cafe/urls.py
@@ -1,10 +1,16 @@
+from django.urls import path
 from rest_framework import routers
 
-from cago.cafe.views import CafeMenuViewSet, CafeViewSet, CustomerProfileViewSet
+from cago.cafe.views import (
+    CafeLikeAPIView,
+    CafeMenuViewSet,
+    CafeViewSet,
+    CustomerProfileViewSet,
+)
 
 cafe_router = routers.SimpleRouter()
 cafe_router.register(r"customer-profiles", CustomerProfileViewSet, "customer-profile")
 cafe_router.register(r"cafes", CafeViewSet, "cafe")
 cafe_router.register(r"menus", CafeMenuViewSet, "menu")
 
-urlpatterns = cafe_router.urls
+urlpatterns = cafe_router.urls + [path("like/", CafeLikeAPIView.as_view(), name="like")]

--- a/cago-server/cago/urls.py
+++ b/cago-server/cago/urls.py
@@ -21,12 +21,12 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-from .cafe.urls import cafe_router
+from .cafe.urls import urlpatterns
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("auth/", include("cago.user.urls", namespace="auth")),
-    path("", include(cafe_router.urls)),
+    path("", include("cago.cafe.urls")),
     path("ping/", include("cago.ping.urls", namespace="ping")),
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path(


### PR DESCRIPTION
- POST /like/
- DELETE /like/
- 두 API에서 cafe (또는 cafe_id) 필드로 카페의 id를 받습니다.
- 로그인한 유저는 GET /cafes/ 또는 GET /cafes/cafe_id/의 'is_liked' 필드로 like했는지 알 수 있습니다.
- `ManagedCafeSerializer`는 카페를 생성/업데이트할 때 사용되는데, 'num_...' 필드는 필요하지 않고, `ManagedCafeReadOnlySerializer`와 코드가 중복되어 해당 필드들은 제거했습니다.